### PR TITLE
Adcded rms-core. RE-RUN meta git update TO INSTALL LOCALLY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ rms-batch-service/
 rms-search-service/
 rms-configuration-repo/
 rms-ng-ui/
+rms-core/

--- a/.meta
+++ b/.meta
@@ -13,6 +13,7 @@
     "rms-search-service": "https://github.com/revature-rms/rms-search-service",
     "rms-configuration-repo": "https://github.com/revature-rms/rms-configuration-repo",
     "rms-auth-service": "https://github.com/revature-rms/rms-auth-service",
-    "rms-ng-ui": "https://github.com/revature-rms/rms-ng-ui"
+    "rms-ng-ui": "https://github.com/revature-rms/rms-ng-ui",
+    "rms-core": "https://github.com/revature-rms/rms-core"
   }
 }


### PR DESCRIPTION
adds rms-core to list of meta repositories so that `meta git update` finds and installs it, as well.